### PR TITLE
yarn example will safe when node version >=8.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "repository": "https://github.com/nitin42/Making-a-custom-React-renderer.git",
   "author": "Nitin <tulswani19@gmail.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=8.1.2"
+  },
   "dependencies": {
     "fbjs": "^0.8.16",
     "officegen": "^0.4.5",


### PR DESCRIPTION
My local node version is 8.0.0, and follow the [Running the project](https://github.com/nitin42/Making-a-custom-React-renderer#running-the-project).

But when I try to execute the `yarn example` and node throw an error below.
![image](https://user-images.githubusercontent.com/6913898/36434263-9b84ae1a-1699-11e8-852d-7ff56ea75b53.png)

I searched the error then and find [this issue](https://github.com/archiverjs/node-archiver/issues/236) about it, I upgrade my node version and everything is ok.

So I think we can use the `engines` field to warn the user to upgrade the node version when theirs is lower.

#### node v8.0.0 warns after adding the `engines` field
![image](https://user-images.githubusercontent.com/6913898/36460853-550a65d6-16f5-11e8-804f-5c72e9e94c47.png)
