### PR TITLE
Install react-devtools in the local node_modules instead of global

### DIFF
--- a/part-one.md
+++ b/part-one.md
@@ -231,13 +231,13 @@ yarn react-devtools
 or if you use npm,
 
 ```
-npm install -g react-devtools
+npm install --save-dev react-devtools
 ```
 
 then run it with
 
 ```
-react-devtools
+npx react-devtools
 ```
 
 ```js


### PR DESCRIPTION
Very small thing, just noticed while reading through. Awesome tutorial btw!